### PR TITLE
Fall back to default content type

### DIFF
--- a/src/deployer.py
+++ b/src/deployer.py
@@ -9,6 +9,7 @@ import pathlib
 import shutil
 
 s3 = boto3.resource('s3')
+defaultContentType = 'application/octet-stream'
 
 def resource_handler(event, context):
   print(event)
@@ -53,6 +54,7 @@ def upload(lambda_src, target_bucket, acl, cacheControl):
 
 def upload_file(source, bucket, key, s3lib, acl, cacheControl, contentType):
     print('uploading from {} {} {}'.format(source, bucket, key))
+    contentType = contentType or defaultContentType
     s3lib.Object(bucket, key).put(ACL=acl, Body=open(source, 'rb'),
                                   CacheControl=cacheControl, ContentType=contentType)
 


### PR DESCRIPTION
If `mimetypes.guess_type()` cannot determine the content type, it returns `None`. Trying to upload an S3 object with `ContentType=None` fails with the following error:

```
{
    "Status": "FAILED",
    "Reason": "Parameter validation failed:\nInvalid type for parameter ContentType, value: None, type: <class 'NoneType'>, valid types: <class 'str'>",
    "PhysicalResourceId": "74c7034c-4bbf-4768-9645-89f68b9fa74a",
    "StackId": "arn:aws:cloudformation:ap-southeast-1:123456789012:stack/jan-test-s3-deploy/09ae9690-6742-11e9-848d-0632875f01f4",
    "RequestId": "74c7034c-4bbf-4768-9645-89f68b9fa74a",
    "LogicalResourceId": "DeploymentResource"
}
```

In my case, it was a source map file (`main.bb26e38e.js.map`) which caused this problem.