### PR TITLE
Add python3.7 runtime & Serverless transform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 output.yml
 build
 output.txt
+setup.cfg

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Before the official announcement for this deployment, if you wanted to deploy your SPA app, along with your other serverless services, to try it out, in the `/example` directory, run:
 
-`make deploy STACK_NAME=<name of cf stack> BUCKET_NAME=<s3 cloudformation deployment bucket>` 
+`make deploy STACK_NAME=<name of cf stack> DEPLOYMENT_BUCKET_NAME=<s3 cloudformation deployment bucket>`
 
 For an explanation of how this works, check out the example [`template.yml`](example/template.yml)
 

--- a/cloudformation/template.yml
+++ b/cloudformation/template.yml
@@ -12,6 +12,7 @@ Resources:
     Properties:
       CompatibleRuntimes:
         - python3.6
+        - python3.7
       Description: S3 Deployment Layer
       LayerName: !Ref AWS::StackName
       LicenseInfo: MIT

--- a/cloudformation/template.yml
+++ b/cloudformation/template.yml
@@ -1,4 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
+Transform: 'AWS::Serverless-2016-10-31'
+
 Description: S3 Deployment Layer
 Parameters:
   DeploymentBucketName:


### PR DESCRIPTION
* Add python3.7 as supported runtime.
* Add Serverless transform, which is required to use `AWS::Serverless::LayerVersion` resource type.